### PR TITLE
fix: add a timeout mechanism that stops acquisition if no data is received for several consecutive transfers

### DIFF
--- a/src/hardware/sipeed-slogic-analyzer/protocol.c
+++ b/src/hardware/sipeed-slogic-analyzer/protocol.c
@@ -40,6 +40,8 @@ static void LIBUSB_CALL receive_transfer(struct libusb_transfer *transfer)
 	int64_t transfers_all_duration =
 		transfers_reached_time_now - devc->transfers_reached_time_start;
 
+	double expected_rate = devc->expected_rate_MBps;
+
 	devc->num_transfers_used -= 1;
 	devc->num_transfers_completed += 1;
 	sr_spew("[%d] Transfer #%d status: %d(%s).",
@@ -77,7 +79,7 @@ static void LIBUSB_CALL receive_transfer(struct libusb_transfer *transfer)
 						  devc->samples_got_nbytes;
 		devc->samples_got_nbytes += transfer->actual_length;
 
-		sr_dbg("[%u] Got %u/%u(%.2f%%) => speed: %.2fMBps, %.2fMBps(avg) => "
+		sr_dbg("[%u] Got %u/%u(%.2f%%) => speed: %.2fMBps, %.2fMBps(avg), %.0fMBps(exp) => "
 		       "+%.3f=%.3fms.",
 		       devc->num_transfers_completed, devc->samples_got_nbytes,
 		       devc->samples_need_nbytes,
@@ -87,6 +89,7 @@ static void LIBUSB_CALL receive_transfer(struct libusb_transfer *transfer)
 			       transfers_reached_duration,
 		       (double)devc->transfers_reached_nbytes /
 			       transfers_all_duration,
+			   expected_rate,
 		       (double)transfers_reached_duration / SR_KHZ(1),
 		       (double)transfers_all_duration / SR_KHZ(1));
 
@@ -141,30 +144,37 @@ static void LIBUSB_CALL receive_transfer(struct libusb_transfer *transfer)
 		break;
 	}
 
-	if (devc->num_transfers_completed &&
-	    (double)transfers_reached_duration / SR_KHZ(1) >
-		    (TRANSFERS_DURATION_TOLERANCE + 1) *
-			    devc->per_transfer_duration) {
+	double actual_rate = (double)devc->transfers_reached_nbytes_latest / transfers_reached_duration;
+	double average_rate = (double)devc->transfers_reached_nbytes / transfers_all_duration;
+	if (devc->num_transfers_completed > 1 &&
+	    ((double)transfers_reached_duration / SR_KHZ(1) >
+		    (TRANSFERS_DURATION_TOLERANCE + 1) * devc->per_transfer_duration ||
+		actual_rate < expected_rate * (1.0 - TRANSFERS_DURATION_TOLERANCE) ||
+		average_rate < expected_rate * 0.95
+	    )
+	) {
 		devc->timeout_count += 1;
-		if (devc->timeout_count > devc->num_transfers_used) {
-			sr_err("Timeout %.3fms!!! Reach duration limit: %.3f(%u+%.1f%%), %.3f > "
-			       "%.3f(%u+%.1f%%)(total) except first one.",
-			       (double)transfers_reached_duration / SR_KHZ(1),
-			       (TRANSFERS_DURATION_TOLERANCE + 1) *
-				       devc->per_transfer_duration,
-			       devc->per_transfer_duration,
-			       TRANSFERS_DURATION_TOLERANCE * 100,
-			       (double)transfers_all_duration / SR_KHZ(1),
-			       (TRANSFERS_DURATION_TOLERANCE + 1) *
-				       devc->per_transfer_duration *
-				       devc->num_transfers_completed,
-			       devc->per_transfer_duration *
-				       (devc->num_transfers_completed + 1),
-			       TRANSFERS_DURATION_TOLERANCE * 100);
-			devc->acq_aborted = 1;
-		}
 	} else {
 		devc->timeout_count = 0;
+	}
+
+	if (devc->timeout_count > devc->num_transfers_used) {
+		sr_err("Timeout %.3fms!!! Rate %.2fMBps(avg)<%.0fMBps(exp) or Reach duration limit: %.3f(%u+%.1f%%), %.3f > "
+				"%.3f(%u+%.1f%%)(total) except first one.",
+				(double)transfers_reached_duration / SR_KHZ(1),
+				average_rate, expected_rate,
+				(TRANSFERS_DURATION_TOLERANCE + 1) *
+					devc->per_transfer_duration,
+				devc->per_transfer_duration,
+				TRANSFERS_DURATION_TOLERANCE * 100,
+				(double)transfers_all_duration / SR_KHZ(1),
+				(TRANSFERS_DURATION_TOLERANCE + 1) *
+					devc->per_transfer_duration *
+					devc->num_transfers_completed,
+				devc->per_transfer_duration *
+					(devc->num_transfers_completed + 1),
+				TRANSFERS_DURATION_TOLERANCE * 100);
+		devc->acq_aborted = 1;
 	}
 
 	if (devc->num_transfers_used == 0) {
@@ -273,6 +283,8 @@ static int train_bulk_in_transfer(struct dev_context *devc,
 	uint64_t bps = sr * ch;
 	uint64_t Bps = bps / 8;
 	uint64_t BpMs = Bps / SR_KHZ(1);
+
+	devc->expected_rate_MBps = BpMs/SR_KHZ(1);
 
 	uint64_t cur_transfer_duration = 250 /* ms */;
 	uint64_t try_transfer_nbytes = cur_transfer_duration * BpMs /* bytes */;

--- a/src/hardware/sipeed-slogic-analyzer/protocol.h
+++ b/src/hardware/sipeed-slogic-analyzer/protocol.h
@@ -75,6 +75,7 @@ struct dev_context {
 		uint64_t cur_samplerate;
 		int32_t cur_samplechannel;
 		int64_t cur_pattern_mode_idx;
+		uint32_t expected_rate_MBps;
 	}; // configuration
 
 	struct {


### PR DESCRIPTION
This issue was reported in [this comment](https://github.com/sigrokproject/libsigrok/pull/275#issuecomment-3592571671) and is now fixed.