### PR TITLE
Ports upstream compilation fixes and forked PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,52 @@
+# original PKGBUILD: https://aur.archlinux.org/packages/libsigrok-git
+# Maintainer: aisuneko icecat <iceneko@protonmail.ch>
+
+# Forked from https://aur.archlinux.org/packages/libsigrok-sipeed-slogic-git. Tracks upstream to github.com/sipeed/libsigrok
+
+_gitname="libsigrok"
+pkgname="libsigrok-sipeed-slogic-git"
+pkgver=r6146.43f554d-1
+pkgrel=1
+pkgdesc="Client software that supports various hardware logic analyzers, core library with Sipeed Slogic Analyzer support patches (git version)"
+arch=('armv6h' 'armv7h' 'i686' 'x86_64')
+url="http://www.sigrok.org/wiki/Libsigrok"
+license=('GPL3')
+depends=('libzip' 'libftdi' 'alsa-lib' 'libserialport-git' 'glibmm' 'libieee1284')
+makedepends=('git' 'autoconf-archive' 'doxygen')
+conflicts=("${_gitname}-git")
+provides=("${_gitname}-git")
+source=("git+https://github.com/sipeed/${_gitname}/#branch=slogic-dev")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_gitname}"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+}
+
+prepare() {
+  cd "${srcdir}/${_gitname}"
+}
+
+
+build() {
+  rm -rf "${srcdir}/build"
+  mkdir -p "${srcdir}/build"
+  cd "${srcdir}/${_gitname}"
+  ./autogen.sh
+
+  cd "${srcdir}/build"
+  echo "CONFIGURE"
+  ../${_gitname}/configure --prefix=/usr --disable-java --disable-ruby
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build"
+
+  make DESTDIR="${pkgdir}" PREFIX=/usr install
+
+  cd ../"${_gitname}"
+  install -Dm 644 'contrib/60-libsigrok.rules' "${pkgdir}/usr/lib/udev/rules.d/60-libsigrok.rules"
+  install -Dm 644 'contrib/61-libsigrok-uaccess.rules' "${pkgdir}/usr/lib/udev/rules.d/61-libsigrok-uaccess.rules"
+}

--- a/bindings/python/sigrok/core/classes.i
+++ b/bindings/python/sigrok/core/classes.i
@@ -74,7 +74,11 @@ typedef guint pyg_flags_type;
      */
     if (!GLib) {
         fprintf(stderr, "Import of gi.repository.GLib failed.\n");
+#if (SWIG_VERSION < 0x040400)
         return nullptr;
+#else
+        return 0;
+#endif
     }
     import_array();
 %}


### PR DESCRIPTION
- Fixes upstream build error as in https://github.com/sigrokproject/libsigrok/pull/280
- Forked the PKGBUILD for https://aur.archlinux.org/packages/libsigrok-sipeed-slogic-git (I'll try to be its maintainer once the package is orphaned)

## TODO
migrate from deprecated setup.py build systems.
```log
libtool: warning: relinking 'bindings/cxx/libsigrokcxx.la'
/usr/lib/python3.14/site-packages/setuptools/_distutils/cmd.py:90: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
/usr/lib/python3.14/site-packages/setuptools/command/sdist.py:123: SetuptoolsDeprecationWarning: `build_py` command does not inherit from setuptools' `build_py`.
!!

        ********************************************************************************
        Custom 'build_py' does not implement 'get_data_files_without_manifest'.
        Please extend command classes from setuptools instead of distutils.

        See https://peps.python.org/pep-0632/ for details.
        ********************************************************************************

!!
  self._add_data_files(self._safe_data_files(build_py))
libtool: warning: remember to run 'libtool --finish /usr/lib'

```