### PR TITLE
sipeed-slogic-analyzer: fix channel count and samplerate list

### DIFF
--- a/src/hardware/sipeed-slogic-analyzer/api.c
+++ b/src/hardware/sipeed-slogic-analyzer/api.c
@@ -537,7 +537,7 @@ int config_channel_set(const struct sr_dev_inst *sdi, struct sr_channel *ch, uns
 		}
 	}
 
-	if(new_samplechannel > devc->cur_samplechannel){
+	if(new_samplechannel != devc->cur_samplechannel){
 		devc->cur_samplechannel = new_samplechannel;
 		devc->limit_samplerate = devc->model->limit_samplerate_table[
 				std_i32_idx(g_variant_new_int32(devc->cur_samplechannel),
@@ -568,11 +568,11 @@ static int config_list(uint32_t key, GVariant **data,
 				      devopts);
 		break;
 	case SR_CONF_SAMPLERATE:
+		/* Always return the full samplerate table. config_set
+		 * enforces the per-channel-count limit at selection time. */
 		*data = std_gvar_samplerates(
 			devc->model->samplerate_table,
-			1 + std_u64_idx(g_variant_new_uint64(
-						devc->limit_samplerate),
-					devc->model->samplerate_table, devc->model->samplerate_table_size));
+			devc->model->samplerate_table_size);
 		if (NULL == devc->model)
 			ret = SR_ERR_ARG;
 		break;


### PR DESCRIPTION
## Summary
- Fix `config_channel_set` to allow **lowering** channel count when disabling channels (was `>`, now `!=`)
- Return full samplerate table in `config_list` instead of truncating based on `limit_samplerate`

## Problem
- Disabling channels in PulseView never reduced `cur_samplechannel`, so users couldn't unlock higher sample rates (e.g. 400MHz@8ch, 800MHz@4ch)
- PulseView queries the rate list before restoring saved channel states, so the truncated list was always stuck at the 16-channel/200MHz limit

## Fix
- `config_channel_set`: change `>` to `!=` so channel count tracks enabled channels in both directions
- `config_list(SR_CONF_SAMPLERATE)`: return all rates; `config_set` already enforces the per-channel-count limit when a rate is selected

## Test plan
- [ ] Connect SLogic 16U3, disable channels D8-D15, verify rates up to 400MHz appear
- [ ] Disable D4-D7 as well, verify rates up to 800MHz appear
- [ ] Re-enable all channels, verify selecting >200MHz gets clamped
- [ ] Start fresh PulseView session with saved 4-channel config, verify full rate list shown